### PR TITLE
FIX:[TE-20950]-expand collapse fix

### DIFF
--- a/src/tree-view/TreeView.tsx
+++ b/src/tree-view/TreeView.tsx
@@ -22,6 +22,7 @@ const ConnectedTreeNode = memo<any>((props) => {
   );
 
   useEffect(() => {
+    if (!expandTree) return;
     setExpandedPaths((prevExpandedPaths) => ({
       ...prevExpandedPaths,
       [path]: expandTree,
@@ -30,7 +31,7 @@ const ConnectedTreeNode = memo<any>((props) => {
 
   return (
     <TreeNode
-      expanded={expanded}
+      expanded={expandTree}
       onClick={handleClick}
       // show arrow anyway even if not expanded and not rendering children
       shouldShowArrow={nodeHasChildNodes}

--- a/src/tree-view/TreeView.tsx
+++ b/src/tree-view/TreeView.tsx
@@ -22,7 +22,6 @@ const ConnectedTreeNode = memo<any>((props) => {
   );
 
   useEffect(() => {
-    if (!expandTree) return;
     setExpandedPaths((prevExpandedPaths) => ({
       ...prevExpandedPaths,
       [path]: expandTree,


### PR DESCRIPTION
### expand collapse functionality  of xml html in rest api

## Jira 
https://testsigma.atlassian.net/browse/TE-20950

### description
- removing the check `if (!expandTree) return;`
- the corresponding change is in https://github.com/TestsigmaInc/groot/tree/fix/TE-20950-expand-collapse-rest-api-fix
- previously when collapse button is pressed -> expandTree=false goes to inspector(in react-inspector)->the previous  code using if clause does not let the tree to collapse
- now here that check is removed 
- but the other affected area is locating element ,there now we are setting expand Tree=true

https://github.com/user-attachments/assets/81f41a4c-afad-448f-afad-4912fe2283a9

